### PR TITLE
fixing outdated profiles link

### DIFF
--- a/config/webnews.rb
+++ b/config/webnews.rb
@@ -9,7 +9,7 @@ NEWS_SERVER = 'news.csh.rit.edu'
 LOCAL_DOMAIN = 'csh.rit.edu'
 
 # URL prefixes for the Profile and Wiki links
-PROFILES_URL = 'https://members.csh.rit.edu/profiles/members/'
+PROFILES_URL = 'https://profiles.csh.rit.edu/user/'
 WIKI_URL = 'https://wiki.csh.rit.edu/wiki/'
 WIKI_USER_URL = WIKI_URL + 'User:'
 


### PR DESCRIPTION
mwoz's profiles has been deprecated in favor of JD's new profiles site, which sits at a different url. This change reflects reality.